### PR TITLE
Initialize backend and frontend structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Crypto Multi-Timeframe Charting Tool
+
+Monorepo containing backend (Express/Prisma) and frontend (React/Vite).
+
+## Backend
+Located in `backend/`. Provides REST API for authentication, Binance data, indicator calculations and AI analysis.
+
+### Env Vars
+See `backend/.env.example` for required environment variables.
+
+## Frontend
+Located in `frontend/`. React application bootstrapped with Vite and Tailwind CSS.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+JWT_SECRET="changeme"
+DATABASE_URL="file:./dev.db"
+OPENAI_API_KEY="your-openai-key"
+BINANCE_BASE_URL="https://api.binance.com"

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "API server for Crypto Multi-Timeframe Charting Tool",
+  "type": "module",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node -e \"console.log('no tests')\""
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "cors": "^2.8.5",
+    "morgan": "^1.10.0",
+    "dotenv": "^16.3.1",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2",
+    "axios": "^1.7.2",
+    "technicalindicators": "^3.1.0",
+    "openai": "^4.0.0",
+    "@prisma/client": "^5.14.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.14.0"
+  }
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,85 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id           Int       @id @default(autoincrement())
+  email        String    @unique
+  passwordHash String
+  createdAt    DateTime  @default(now())
+  preferences  Preferences?
+  analyses     Analysis[]
+  memberships  Membership[]
+  notifications Notification[]
+}
+
+model Preferences {
+  id              Int    @id @default(autoincrement())
+  favoriteSymbols String @default("[]")
+  userId          Int    @unique
+  user            User   @relation(fields: [userId], references: [id])
+}
+
+model Analysis {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  symbol    String
+  interval  String
+  result    Json
+  createdAt DateTime @default(now())
+  shared    SharedAnalysis?
+}
+
+model Team {
+  id        Int          @id @default(autoincrement())
+  name      String
+  createdAt DateTime     @default(now())
+  memberships Membership[]
+  auditLogs  AuditLog[]
+  sharedAnalyses SharedAnalysis[]
+}
+
+model Membership {
+  id     Int    @id @default(autoincrement())
+  team   Team   @relation(fields: [teamId], references: [id])
+  teamId Int
+  user   User   @relation(fields: [userId], references: [id])
+  userId Int
+  role   String @default("member")
+}
+
+model SharedAnalysis {
+  id         Int      @id @default(autoincrement())
+  team       Team     @relation(fields: [teamId], references: [id])
+  teamId     Int
+  analysis   Analysis @relation(fields: [analysisId], references: [id])
+  analysisId Int      @unique
+  createdAt  DateTime @default(now())
+}
+
+model AuditLog {
+  id        Int      @id @default(autoincrement())
+  team      Team     @relation(fields: [teamId], references: [id])
+  teamId    Int
+  user      User?    @relation(fields: [userId], references: [id])
+  userId    Int?
+  action    String
+  createdAt DateTime @default(now())
+}
+
+model Notification {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  type      String
+  title     String
+  message   String
+  read      Boolean  @default(false)
+  createdAt DateTime @default(now())
+}

--- a/backend/src/aiAnalysis.js
+++ b/backend/src/aiAnalysis.js
@@ -1,0 +1,30 @@
+import OpenAI from 'openai';
+import { fetchCandles } from './binanceService.js';
+import { calculateRSI, calculateMACD, calculateBollinger, calculateKDJ, calculateATR } from './indicatorService.js';
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function analyzeWithAI({ symbol, intervals }) {
+  const allData = {};
+  for (const interval of intervals) {
+    const candles = await fetchCandles(symbol, interval);
+    const closes = candles.map(c => c.close);
+    const highs = candles.map(c => c.high);
+    const lows = candles.map(c => c.low);
+    allData[interval] = {
+      candles,
+      indicators: {
+        rsi: calculateRSI(closes),
+        macd: calculateMACD(closes),
+        bollinger: calculateBollinger(closes),
+        kdj: calculateKDJ(highs, lows, closes),
+        atr: calculateATR(highs, lows, closes)
+      }
+    };
+  }
+
+  const prompt = `Act as an ETH/AVAX futures trader. Analyze the following multi-timeframe data for ${symbol} and provide signals. Data: ${JSON.stringify(allData)}.`;
+  const response = await client.responses.create({ model: 'gpt-4o-mini', input: prompt });
+  const text = response.output[0].content[0].text;
+  return { raw: text };
+}

--- a/backend/src/binanceService.js
+++ b/backend/src/binanceService.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+const baseURL = process.env.BINANCE_BASE_URL || 'https://api.binance.com';
+
+export async function fetchCandles(symbol, interval, limit = 500) {
+  const url = `${baseURL}/api/v3/klines`;
+  const params = { symbol, interval, limit };
+  const { data } = await axios.get(url, { params });
+  return data.map(c => ({
+    openTime: c[0],
+    open: parseFloat(c[1]),
+    high: parseFloat(c[2]),
+    low: parseFloat(c[3]),
+    close: parseFloat(c[4]),
+    volume: parseFloat(c[5]),
+    closeTime: c[6]
+  }));
+}

--- a/backend/src/fundamentalsService.js
+++ b/backend/src/fundamentalsService.js
@@ -1,0 +1,4 @@
+export async function fetchFundamentals(symbol) {
+  // TODO: integrate CoinGecko/CryptoPanic APIs
+  return { message: 'Fundamentals data not implemented', symbol };
+}

--- a/backend/src/indicatorService.js
+++ b/backend/src/indicatorService.js
@@ -1,0 +1,21 @@
+import { RSI, MACD, BollingerBands, KDJ, ATR } from 'technicalindicators';
+
+export function calculateRSI(closes, period = 14) {
+  return RSI.calculate({ values: closes, period });
+}
+
+export function calculateMACD(closes) {
+  return MACD.calculate({ values: closes, fastPeriod: 12, slowPeriod: 26, signalPeriod: 9, SimpleMAOscillator: false, SimpleMASignal: false });
+}
+
+export function calculateBollinger(closes) {
+  return BollingerBands.calculate({ period: 20, stdDev: 2, values: closes });
+}
+
+export function calculateKDJ(highs, lows, closes) {
+  return KDJ.calculate({ high: highs, low: lows, close: closes, period: 14 });
+}
+
+export function calculateATR(highs, lows, closes) {
+  return ATR.calculate({ high: highs, low: lows, close: closes, period: 14 });
+}

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,16 @@
+import jwt from 'jsonwebtoken';
+
+export function authRequired(req, res, next) {
+  const auth = req.headers.authorization;
+  if (!auth || !auth.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  const token = auth.substring(7);
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = payload;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}

--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { analyzeWithAI } from '../aiAnalysis.js';
+
+const router = Router();
+
+router.post('/analyze', async (req, res, next) => {
+  try {
+    const { symbol, intervals } = req.body;
+    const result = await analyzeWithAI({ symbol, intervals });
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,0 +1,51 @@
+import { Router } from 'express';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { PrismaClient } from '@prisma/client';
+import { authRequired } from '../middleware/auth.js';
+
+const prisma = new PrismaClient();
+const router = Router();
+
+router.post('/register', async (req, res, next) => {
+  try {
+    const { email, password } = req.body;
+    if (!email || !password) {
+      return res.status(400).json({ error: 'Email and password required' });
+    }
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      return res.status(409).json({ error: 'User already exists' });
+    }
+    const passwordHash = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({ data: { email, passwordHash } });
+    res.json({ id: user.id, email: user.email });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/login', async (req, res, next) => {
+  try {
+    const { email, password } = req.body;
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+    const valid = await bcrypt.compare(password, user.passwordHash);
+    if (!valid) return res.status(401).json({ error: 'Invalid credentials' });
+    const token = jwt.sign({ id: user.id, email: user.email }, process.env.JWT_SECRET, { expiresIn: '7d' });
+    res.json({ token });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/me', authRequired, async (req, res, next) => {
+  try {
+    const user = await prisma.user.findUnique({ where: { id: req.user.id }, select: { id: true, email: true, createdAt: true } });
+    res.json(user);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/routes/binance.js
+++ b/backend/src/routes/binance.js
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import { fetchCandles } from '../binanceService.js';
+
+const router = Router();
+const intervals = ['1m','5m','15m','30m','1h','2h','4h','8h','12h','1d','1w'];
+
+router.get('/candles/:symbol/:interval', async (req, res, next) => {
+  try {
+    const { symbol, interval } = req.params;
+    if (!intervals.includes(interval)) {
+      return res.status(400).json({ error: 'Unsupported interval' });
+    }
+    const candles = await fetchCandles(symbol.toUpperCase(), interval);
+    res.json(candles);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/routes/indicators.js
+++ b/backend/src/routes/indicators.js
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import { fetchCandles } from '../binanceService.js';
+import { calculateRSI, calculateMACD, calculateBollinger, calculateKDJ, calculateATR } from '../indicatorService.js';
+
+const router = Router();
+
+router.get('/indicators/:symbol/:interval', async (req, res, next) => {
+  try {
+    const { symbol, interval } = req.params;
+    const candles = await fetchCandles(symbol.toUpperCase(), interval);
+    const closes = candles.map(c => c.close);
+    const highs = candles.map(c => c.high);
+    const lows = candles.map(c => c.low);
+    res.json({
+      rsi: calculateRSI(closes),
+      macd: calculateMACD(closes),
+      bollinger: calculateBollinger(closes),
+      kdj: calculateKDJ(highs, lows, closes),
+      atr: calculateATR(highs, lows, closes)
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,40 @@
+import express from 'express';
+import cors from 'cors';
+import morgan from 'morgan';
+import dotenv from 'dotenv';
+
+import authRoutes from './routes/auth.js';
+import binanceRoutes from './routes/binance.js';
+import indicatorRoutes from './routes/indicators.js';
+import aiRoutes from './routes/ai.js';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(morgan('dev'));
+app.use(express.json());
+
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.use('/api/auth', authRoutes);
+app.use('/api', binanceRoutes);
+app.use('/api', indicatorRoutes);
+app.use('/api/ai', aiRoutes);
+
+// error handler
+app.use((err, req, res, next) => {
+  console.error(err); // eslint-disable-line no-console
+  res.status(err.status || 500).json({ error: err.message || 'Server error' });
+});
+
+export default app;
+
+if (process.env.NODE_ENV !== 'test') {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`); // eslint-disable-line no-console
+  });
+}

--- a/backend/src/whalesService.js
+++ b/backend/src/whalesService.js
@@ -1,0 +1,4 @@
+export async function fetchWhaleActivity(symbol) {
+  // TODO: integrate Whale Alert API
+  return { message: 'Whale activity not implemented', symbol };
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Crypto Multi-Timeframe Charting Tool</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "node -e \"console.log('no tests')\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.7.2"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.32",
+    "autoprefixer": "^10.4.17"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function App() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Crypto Multi-Timeframe Charting Tool</h1>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+createRoot(document.getElementById('root')).render(<App />);

--- a/frontend/src/pages/Auth.jsx
+++ b/frontend/src/pages/Auth.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function AuthPage() {
+  return (
+    <div>
+      <h2>Login / Register</h2>
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function DashboardPage() {
+  return (
+    <div>
+      <h2>Dashboard</h2>
+    </div>
+  );
+}

--- a/frontend/src/pages/Notifications.jsx
+++ b/frontend/src/pages/Notifications.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function NotificationsPage() {
+  return (
+    <div>
+      <h2>Notifications</h2>
+    </div>
+  );
+}

--- a/frontend/src/pages/Status.jsx
+++ b/frontend/src/pages/Status.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function StatusPage() {
+  return (
+    <div>
+      <h2>Status</h2>
+    </div>
+  );
+}

--- a/frontend/src/pages/Teams.jsx
+++ b/frontend/src/pages/Teams.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function TeamsPage() {
+  return (
+    <div>
+      <h2>Teams</h2>
+    </div>
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+const api = axios.create({ baseURL: '/api' });
+
+export default api;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- set up Express backend with health check, JWT auth routes, Binance and indicator services, and AI analysis stub
- define Prisma schema for users, teams, analyses, notifications and related models
- scaffold React+Vite frontend with Tailwind configuration and basic pages

## Testing
- `npm test` (backend)
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68b48ce1b3d48326b529d01ec0ed65d6